### PR TITLE
Fixed bug with exceuteRemoteJob not using specified remote (used default)

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -695,6 +695,7 @@ function executeRemoteJob(remoteName, path, method, body, callback) {
 
   var result = null;
   var options = {
+    remote: remoteName,
     apiVersion: '1.0',
     expectedStatusCodes: [200],
     parseJson: true


### PR DESCRIPTION
exceuteRemoteJob would always use the default remote, never the remote specified by -r/--remote
