### PR TITLE
Fixed double callback invoke that would break deployments and crash agent

### DIFF
--- a/lib/deployment/files.js
+++ b/lib/deployment/files.js
@@ -109,11 +109,11 @@ function resolveDataFiles(extractedBundlePath, dataPath, instancePath, dataFiles
                                       callback);
                 return;
               });
+            } else {
+              // Ignore this path. It is a file but user did not specify mandatory
+              // trailing slash
+              callback();
             }
-
-            // Ignore this path. It is a file but user did not specify mandatory
-            // trailing slash
-            callback();
           }
           else {
             directoryString = getDirectoryStringFromPath(dataFile);


### PR DESCRIPTION
An async.forEachSeries iterators callback was being fired twice. This only manifested when cast.json data_files included a dir and that dir needed to be copied to the instance data during deployment. The deployment would claim to complete, but not symlink the dir. The agent would then crash when async tried another pass with a bad dataFile var. 

```
opt/cast/cast/lib/deployment/files.js:95
    var dataFileIsDirectory = (dataFile[dataFile.length - 1] === '/');
                                                ^
TypeError: Cannot read property 'length' of undefined
    at /opt/cast/cast/lib/deployment/files.js:95:49
    at /opt/cast/cast/node_modules/async/lib/async.js:91:13
    at /opt/cast/cast/node_modules/async/lib/async.js:99:26
    at addToPathsToLinkArray (/opt/cast/cast/lib/deployment/files.js:51:5)
    at /opt/cast/cast/lib/deployment/files.js:111:17
    at callback (/opt/cast/cast/lib/util/fs.js:198:5)
    at dirdone (/opt/cast/cast/lib/util/fs.js:241:17)
    at callback (/opt/cast/cast/lib/util/fs.js:198:5)
    at dirdone (/opt/cast/cast/lib/util/fs.js:241:17)
    at callback (/opt/cast/cast/lib/util/fs.js:198:5)
```
